### PR TITLE
Refactoring to be more go friendly

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,10 +1,8 @@
 package govh
 
-import (
-	"fmt"
-)
+import "fmt"
 
-// ApiOvhError is a struct representing an error that can occured while calling API.
+// ApiOvhError represents an error that can occured while calling the API.
 type ApiOvhError struct {
 	// Error message.
 	Message string
@@ -15,5 +13,5 @@ type ApiOvhError struct {
 }
 
 func (err *ApiOvhError) Error() string {
-	return fmt.Sprintf("Error %d : %s", err.Code, err.Message)
+	return fmt.Sprintf("Error %d : %q", err.Code, err.Message)
 }


### PR DESCRIPTION
### Changes:
* govet and golint compliant
* use time.Time and time.Duration instead of timestamps
* removed useless fmt...
* more readable signature

### Breaking change:
```caller.CallApi``` is now ```caller.CallAPI``` this can be changed if you really don't want to break the current API (but I wouldn't be golint compliant anymore)